### PR TITLE
feat: support listen reuseport mode

### DIFF
--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ type Options struct {
 
 	// acceptor options
 	reuseAddr     bool // SO_REUSEADDR
+	reusePort     bool // SO_REUSEPORT
 	listenBacklog int  //
 
 	// connector options
@@ -35,6 +36,7 @@ func setOptions(optL ...Option) {
 		//= defaut options
 		evOptions = &Options{
 			reuseAddr:            true,
+			reusePort:            false,
 			evPollNum:            1,
 			evReadyNum:           512,
 			evDataArrSize:        8192,
@@ -58,7 +60,14 @@ func ReuseAddr(v bool) Option {
 	}
 }
 
-// ListenBacklog for syscall.listen(fd, backlog), also affect `for i < backlog/2 { syscall.accept() }`
+// ReusePort for SO_REUSEADDR
+func ReusePort(v bool) Option {
+	return func(o *Options) {
+		o.reusePort = v
+	}
+}
+
+// Listen backlog, For syscall.listen(fd, backlog), also affect `for i < backlog/2 { syscall.accept() }`
 func ListenBacklog(v int) Option {
 	return func(o *Options) {
 		o.listenBacklog = v


### PR DESCRIPTION
### change 

增加了 socket reuseport 多进程端口绑定的特性.

新版的 golang 的 syscall 库包里没有 reuseport 的定义，只有 reuseaddr 定义，所以使用 unix 引用 reuseport 标记。